### PR TITLE
📚 Update links to kraggl.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ With detailed time entry descriptions and tags depending of the state your task 
 
 ## Getting started
 
-Head over to [Kraggl](https://kraggl.lichtblau.io).
+Head over to [Kraggl](https://kraggl.com).
 
 Or get the Express server running locally:
 

--- a/controllers/glo.js
+++ b/controllers/glo.js
@@ -2,7 +2,7 @@ const authHelper = require('../helpers/auth');
 const timeHelper = require('../helpers/time');
 
 const COMMENT_HEADER = '# Time Summary\n\n';
-const COMMENT_FOOTER = '\n\nPowered By: [Kraggl](https://kraggl.lichtblau.io)';
+const COMMENT_FOOTER = '\n\nPowered By: [Kraggl](https://kraggl.com)';
 
 const isColumnTracked = (columnId, board) => board.Columns.map(col => col.id).includes(columnId);
 


### PR DESCRIPTION
As stated in mlichtblau/kraggl#11, kraggl was moved to a new website. My commit updates the link in your README.md.

I propose to change the project website to https://kraggl.com, as well.